### PR TITLE
Media grid delete

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -68,10 +68,6 @@ var timeoutId;
 			wpMediaGrid.viewCount();
 			
 			//Toggle Select all viewable items
-			$( '.media-select-all ' ).poshytip({
-				content: 'All viewable items',
-				hideTimeOut: '5000'
-			});
 			$( '.media-select-all input[type=checkbox]' ).on('click', function() {
 				wpMediaGrid.toggleSelectAll();				
 			});

--- a/scripts.js
+++ b/scripts.js
@@ -149,6 +149,8 @@ var timeoutId;
 								//get the response in readable form
 								var responseID = $.parseJSON(response);
 								wpMediaGrid.gridDelete(responseID);
+								wpMediaGrid.showUpdate();
+								wpMediaGrid.initLiveSearch();
 							}else {
 								alert('Something went wrong.  Please try again later');
 							}
@@ -195,6 +197,8 @@ var timeoutId;
 								});
 								count = 0;
 								wpMediaGrid.selectedMediaPopup(count);
+								wpMediaGrid.showUpdate(responseID.length);
+								wpMediaGrid.initLiveSearch();
 							}else {
 								alert('Something went wrong.  Please try again later');
 							}
@@ -335,7 +339,6 @@ var timeoutId;
 					itemDel.trigger( 'click' );
 				}
 				itemDel.remove();
-				wpMediaGrid.initLiveSearch();
 				wpMediaGrid.totalCount();
 				wpMediaGrid.viewCount();
 				
@@ -349,6 +352,18 @@ var timeoutId;
 			return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
 		},
 		
+		//show update div with positive feedback that item(s) were deleted
+		showUpdate: function(num) {
+			var messageNum = num + '  Media attachments permanently deleted';
+				message = 'Media attachment permanently deleted';
+			
+			if(num) {
+				$('#message').text(messageNum);
+			}else {
+				$('#message').text(message);
+			}
+			$('#message').fadeIn().delay(6000).fadeOut();
+		},
 		// Total number of items on the page
 		viewCount: function() {
 			var onPage = $('.media-grid .media-item:visible'),

--- a/scripts.js
+++ b/scripts.js
@@ -102,9 +102,10 @@ var timeoutId;
 			$( '#selected-media-details' ).on( 'click', '.selected-unselect', function(event) {
 				event.preventDefault();
 				
+				$('.media-select-all input[type=checkbox]').removeAttr('checked');
+				wpMediaGrid.toggleSelectAll();
 				count = 0;
 				wpMediaGrid.selectedMediaPopup(count);
-				wpMediaGrid.toggleSelectAll();
 			});
 			
 			// Close modal
@@ -424,7 +425,7 @@ var timeoutId;
 				//show count 
 				$('#selected-media-details .selected-count strong' ).html(count);		
 			}else {
-				media_details.fadeOut(400);
+				media_details.fadeOut(100);
 			}
 			
 			

--- a/scripts.js
+++ b/scripts.js
@@ -16,7 +16,6 @@ var timeoutId;
 					next_page = parseInt( link.attr('href') ) + 1,
 					filter = '',
 					tag = '';
-
 				filter = $( '.media-nav' ).data( 'filter' );
 				tag = $( '.media-nav' ).data( 'tag' );
 				link.addClass( 'loading' ).html( 'Loading more items&hellip;' );
@@ -36,6 +35,13 @@ var timeoutId;
 						link.remove();
 					}
 					wpMediaGrid.initLiveSearch();
+					wpMediaGrid.totalCount();
+					if(  $('.media-select-all input').is(":checked") ) {
+						if( confirm( 'Select next page worth of items?' ) ) {
+							wpMediaGrid.toggleSelectAll();
+						}
+					}
+					
 				});
 			});
 
@@ -57,7 +63,25 @@ var timeoutId;
 
 			// Live search of viewable items
 			wpMediaGrid.initLiveSearch();
-
+			
+			//Initial Display viewable items count
+			wpMediaGrid.totalCount();
+			
+			//Toggle Select all viewable items
+			$( '.media-select-all input[type=checkbox]' ).on('click', function() {
+				wpMediaGrid.toggleSelectAll();				
+			});
+			//Select single item
+			$('.media-select input[type=checkbox]').on('click', function() {
+				var item = $(this).closest( '.media-item' );
+				console.log('Item is: ' + item);
+				if( $(this).is(":checked") ) {
+					item.addClass('selected');
+				}else {
+					item.removeClass('selected');
+				}
+			});
+			
 			// Close modal
 			$( '#media-modal .close-button' ).on( 'click', function() {
 				wpMediaGrid.closeModal();
@@ -68,12 +92,12 @@ var timeoutId;
 				$( this ).select();
 			} );
 
-			// View Item
+			 //View Item
 			$( '.media-grid' ).on( 'click', '.media-thumb', function(event) {
 				var item = $( this ).closest( '.media-item' );
 				wpMediaGrid.openModal( item );
 			} );
-
+			
 			// Delete Single Item
 			$( '.media-grid' ).on( 'click', '.media-delete', function( event ) {
 				event.preventDefault();
@@ -167,7 +191,6 @@ var timeoutId;
 						current_item = $( '#' + current_item_id ),
 						prev_item = current_item.prev( '.media-item' ),
 						next_item = current_item.next( '.media-item' );
-
 					if (e.keyCode == 37) {
 						wpMediaGrid.clearModal();
 						prev_item.find( '.media-thumb' ).trigger( 'click' );
@@ -224,7 +247,48 @@ var timeoutId;
 			var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
 				results = regex.exec(location.search);
 			return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+		},
+		
+		// Total number of items on the page
+		totalCount: function() {
+			var onPage = $('.media-grid .media-item:visible'),
+				displayTotalCount = $( '.media-nav #view-items' );
+			if(onPage) {
+				displayTotalCount.html(onPage.length + ' <span>viewable</span>');
+			}
+		},
+		
+		//Select all viewable items on page
+		toggleSelectAll: function() {
+			//Check to see if things are already checked
+			if(  $('.media-select-all input').is(":checked") ) {
+				$( '.media-grid .media-item').each(function() {
+					var id = $(this).data('id'),
+						details = $(this).find( '.media-details' ),
+						selected = $('#selected-media-details .selected-media');
+						
+					if( $(this).hasClass('selected')) {
+						//Do nothing
+					} else {
+						if ( $(this).is(':visible')) {
+							$( this ).addClass('selected');
+							$(this).find( '.media-select input[type=checkbox]' ).attr('checked','checked');
+							selected.hide().prepend('<li class="selected-details" id="detail-' + id + '" data-id="' + id + '">'  + details.html() + '</li>').fadeIn(500);
+							selected.find('#detail-' + id + ' .media-options').hide();
+							selected.find('#detail-' + id + ' h3').hide();
+							selected.find('#detail-' + id + ' .media-meta').hide();
+						} 
+						//$('.media-select-all').text('Uncheck All');
+					}
+				});
+			} else {
+				$( '.media-grid > .media-item' ).removeClass('selected');
+				$( '.media-grid > .media-item .media-select input[type=checkbox]' ).removeAttr('checked');
+				$( '#selected-media-details .selected-media li' ).remove();
+				$('.media-select-all').html('Check All');
+			} 
 		}
+		
 	}
 
 	$(document).ready(function($){ wpMediaGrid.init(); });

--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,10 @@ body.blurred #media-library .media-grid {
 	font-size: 10px;
 	margin-left: 1px;
 }
+#total-items span.found {
+	font-size: inherit;
+	margin-left: 0;
+}
 #view-items {
 	float: left;
 	color: #999;
@@ -333,7 +337,9 @@ ul.media-nav {
 	.media-item:hover .media-thumb {
 		background: rgba(0,0,0,0.1);
 	}
-
+	.media-item:hover .media-details h3 {
+		opacity: 0.1;
+	}
 .media-item.selected {
 }
 	.media-item.selected .media-thumb {
@@ -425,12 +431,12 @@ ul.media-nav {
 			top: -2px;
 		padding: 0 5px 0 0;
 	}
-	.media-options a.submitdelete {
+	.media-options a.media-delete {
 		color: #fff;
 		padding: 3px 3px;
 		border-left: 1px dotted rgba(255,255,255,0.3);
 	}
-	.media-options a.submitdelete:before {
+	.media-options a.media-delete:before {
 		content: '\f182';
 		color: #fff;
 		display: inline-block;

--- a/styles.css
+++ b/styles.css
@@ -702,6 +702,11 @@ dd.photo-uploader {
     opacity: 0.5;
     z-index: 10000;
 }
-#message {
+body #media-library #message {
 	display: none;
+	margin: 5px 0 30px;
+}
+/*  Trying to override dashicons-trash icon which is broken in latest wordpress update (3.8.1) */
+#media-library .selected-delete .dashicons-trash:before {
+	content: "\f182";
 }

--- a/styles.css
+++ b/styles.css
@@ -689,6 +689,19 @@ dd.photo-uploader {
 		.star-rating .star b {
 			display: none;
 		}
+#media-overlay {
+	position: fixed;
+    top: 200px;
+    left: 180px;
+    width: 100%;
+    height: 100%;
+    background-color: #fff;
+    filter:alpha(opacity=50);
+    -moz-opacity:0.5;
+    -khtml-opacity: 0.5;
+    opacity: 0.5;
+    z-index: 10000;
+}
 #message {
 	display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -689,3 +689,6 @@ dd.photo-uploader {
 		.star-rating .star b {
 			display: none;
 		}
+#message {
+	display: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,62 @@ body.blurred #media-library .media-grid {
 #media-library .media-grid {
 	transition: opacity 0.2s ease-in-out;
 }
-
+#media-library ul.media-nav li.media-select-all {
+	float: right;
+	margin: 5px 15px 0 5px;
+}
+#total-items {
+	float: left;
+	color: #999;
+}
+#total-items span {
+	font-size: 10px;
+	margin-left: 1px;
+}
+#view-items {
+	float: left;
+	color: #999;
+}
+#view-items span{
+	font-size: 10px;
+	margin-left: 1px;
+}
+#view-items:before {
+	content: "\f139";
+	-webkit-font-smoothing: antialiased;
+	font: normal 16px/1 'dashicons';
+	vertical-align: middle;
+	position: relative;
+		top: -2px;
+}
+#media-library ul.media-nav li.media-select-all {
+	float: right;
+	margin: 5px 15px 0 5px;
+}
+#total-items {
+	float: left;
+	color: #999;
+}
+#total-items span {
+	font-size: 10px;
+	margin-left: 1px;
+}
+#view-items {
+	float: left;
+	color: #999;
+}
+#view-items span{
+	font-size: 10px;
+	margin-left: 1px;
+}
+#view-items:before {
+	content: "\f139";
+	-webkit-font-smoothing: antialiased;
+	font: normal 16px/1 'dashicons';
+	vertical-align: middle;
+	position: relative;
+		top: -2px;
+}
 #media-list-button {
 	font-size: 13px;
 	margin-left: 10px;
@@ -44,10 +99,15 @@ body.blurred #media-library .media-grid {
 		top: -2px;
 }
 
+
+
 ul.media-nav {
+	/*
 	position: absolute;
 		top: 0;
 		right: 0;
+		*/
+	overflow: hidden;
 }
 	ul.media-nav li {
 		display: inline-block;
@@ -300,7 +360,7 @@ ul.media-nav {
 
 
 .media-options {
-	margin: 0;
+	margin: -20px 0 0 0;
 	padding: 3px 8px;
 	opacity: 0;
 	list-style: none;
@@ -352,7 +412,7 @@ ul.media-nav {
 	.media-options a.media-edit {
 		color: #fff;
 		padding: 5px 10px;
-		border-left: 1px dotted rgba(255,255,255,0.3);
+		/*border-left: 1px dotted rgba(255,255,255,0.3);*/
 	}
 	.media-options a.media-edit:before {
 		content: '\f111';
@@ -365,7 +425,22 @@ ul.media-nav {
 			top: -2px;
 		padding: 0 5px 0 0;
 	}
-
+	.media-options a.submitdelete {
+		color: #fff;
+		padding: 3px 3px;
+		border-left: 1px dotted rgba(255,255,255,0.3);
+	}
+	.media-options a.submitdelete:before {
+		content: '\f182';
+		color: #fff;
+		display: inline-block;
+		-webkit-font-smoothing: antialiased;
+		font: normal 16px/1 'dashicons';
+		vertical-align: middle;
+		position: relative;
+			top: -2px;
+		padding: 0 5px 0 0;
+	}
 
 #media-modal {
 	display: none;

--- a/styles.css
+++ b/styles.css
@@ -157,14 +157,49 @@ ul.media-nav {
 	position: fixed;
 		right: 40px;
 		left: 180px;
-		bottom: 0;
+		bottom: 25px;
 	z-index: 20;
-	border-top: 2px solid #ccc;
-	background: rgba(255,255,255,0.95);
+	border: 2px solid #444;	
+	-webkit-border-radius: 10px;
+	-moz-border-radius: 10px;
+	border-radius: 10px;
+	background: rgba(34, 34, 34, 0.9);
 }
 	.selected-meta {
+		width: 400px;
+		margin: 0 auto;
+		overflow: hidden;
+	}
+	#selected-media-details button.bttn_clear_all {
+		cursor: pointer;
+		color: #e9e9e9;
+		font-size: 9px;
+		text-align: center;
+		//padding: .5em 2em .55em;
+		text-shadow: 0 1px 1px rgba(1,1,1,.3);
+		outline: none;
+		border: solid 1px #555;
+		-moz-border-radius: .4em;
+		-webkit-border-radius: .4em;
+		border-radius: .4em;
+		-webkit-box-shadow: 0 1px 2px rgba(0,0,0,.3);
+		-moz-box-shadow: 0 1px 2px rgba(0,0,0,.3);
+		box-shadow: inset 0 1px 2px rgba(0,0,0,0.3);
+		background: #616161;
+		background: -webkit-gradient(linear, left top, left bottom, from(#757575), to(#4b4b4b));
+		background: -moz-linear-gradient(top,  #888,  #575757);
+		//filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#faa51a', endColorstr='#f47a20');
+	}
+		#selected-media-details button.bttn_clear_all:hover {
+			box-shadow: inset 0 1px 2px rgba(0,173,238,0.3);
+			background: #616161;
+			background: -webkit-gradient(linear, left top, left bottom, from(#757575), to(#4b4b4b));
+		}
+	#selected-media-details h2 {
+		color: #ccc;
 	}
 	#selected-media-details h2.selected-count {
+		float: left;
 		font-size: 13px;
 		font-weight: 300;
 		margin: 0;
@@ -173,27 +208,36 @@ ul.media-nav {
 	}
 
 	.selected-media-options {
-		margin: 0 0 5px 0;
+		float: left;
+		margin: 0;
+		padding: 13px 0 12px 0;
 		line-height: 1;
 		font-size: 12px;
 	}
 		.selected-media-options li {
 			display: inline-block;
-			margin-right: 5px;
+			margin-left: 10px;
+			margin-bottom: 0;
+			vertical-align: bottom;
 		}
 	.selected-media-options.inactive a {
 		color: #aaa;
 		text-decoration: none;
 		cursor: pointer;
+		height: 16px;
+		overflow: hidden;
 	}
 	.selected-media-options.active {}
 
 	.selected-media {
+		clear: both;
 		margin: 0;
 		padding: 0;
 		list-style: none;
+		overflow: hidden;
 		min-height: 50px;
 	}
+	
 	.selected-media:after {
 		content: ".";
 		display: block;
@@ -201,19 +245,22 @@ ul.media-nav {
 		clear: both;
 		visibility: hidden;
 	}
+	
 		.selected-media > li {
 			float: left;
 			margin: 0 5px 5px 0;
-			height: 45px;
-			width: 45px;
+			padding: 0px;
+			/*height: 45px;
+			width: 45px;*/
 			text-align: center;
-			border: 1px solid rgba(0,0,0,0.2);
-			background: rgba(255,255,255,0.3);
+			/*border: 1px solid rgba(0,0,0,0.2);*/
+			background: rgba(204,204,204,0.3); 
+			overflow: hidden;
 		}
 		.selected-media img {
 			display: inline-block;
 			max-height: 45px;
-			max-width: 45px;
+			max-width: 65px;
 		}
 		.selected-media .media-tags {
 			display: none;
@@ -224,6 +271,7 @@ ul.media-nav {
 		.selected-media .media-options {
 			display: none;
 		}
+
 
 
 .media-item {
@@ -313,7 +361,10 @@ ul.media-nav {
 		background: rgba(0,0,0,0.1);
 	}
 	.media-item:hover .media-details h3 {
-		opacity: 0.1;
+		background: rgba(0,0,0,0.6);
+		color: #fff;
+		box-shadow: inset 0 0 0 1px rgba(0,0,0,0.05); 
+		//opacity: 0.1;
 	}
 .media-item.selected {
 }
@@ -341,14 +392,14 @@ ul.media-nav {
 
 
 .media-options {
-	margin: -20px 0 0 0;
+	margin: 0;
 	padding: 3px 8px;
 	opacity: 0;
 	list-style: none;
 	position: absolute;
-		right: 0;
-		bottom: 0;
-		left: 0;
+		right: 5px;
+		bottom: 45px;
+		left: 5px;
 	z-index: 20;
 	text-align: center;
 	border-top: 1px solid rgba(0,0,0,0.3);
@@ -386,8 +437,8 @@ ul.media-nav {
 		.media-options li.media-select input[type=checkbox] {
 			border: 1px solid rgba(0,0,0,0.6) !important;
 			box-shadow: inset 0 2px 2px rgba(0,0,0,0.2);
-			height: 25px;
-			width: 25px;
+			height: 20px;
+			width: 20px;
 			padding: 4px !important;
 		}
 	.media-options a.media-edit {

--- a/styles.css
+++ b/styles.css
@@ -28,49 +28,23 @@ body.blurred #media-library .media-grid {
 #media-library .media-grid {
 	transition: opacity 0.2s ease-in-out;
 }
+
 #media-library ul.media-nav li.media-select-all {
 	float: right;
 	margin: 5px 15px 0 5px;
+	width: 7em;
+}
+#total-view-items  {
+	padding: 10px 0 0 0;
 }
 #total-items {
 	float: left;
 	color: #999;
+	font-size: 10px;
 }
 #total-items span {
-	font-size: 10px;
-	margin-left: 1px;
-}
-#total-items span.found {
-	font-size: inherit;
-	margin-left: 0;
-}
-#view-items {
-	float: left;
-	color: #999;
-}
-#view-items span{
-	font-size: 10px;
-	margin-left: 1px;
-}
-#view-items:before {
-	content: "\f139";
-	-webkit-font-smoothing: antialiased;
-	font: normal 16px/1 'dashicons';
-	vertical-align: middle;
-	position: relative;
-		top: -2px;
-}
-#media-library ul.media-nav li.media-select-all {
-	float: right;
-	margin: 5px 15px 0 5px;
-}
-#total-items {
-	float: left;
-	color: #999;
-}
-#total-items span {
-	font-size: 10px;
-	margin-left: 1px;
+	font-size: 13px;
+	margin-right: 2px;
 }
 #view-items {
 	float: left;
@@ -110,15 +84,16 @@ ul.media-nav {
 	position: absolute;
 		top: 0;
 		right: 0;
-		*/
+	*/	
 	overflow: hidden;
+	margin: 0
 }
 	ul.media-nav li {
 		display: inline-block;
 		margin-right: 10px;
 	}
 	ul.media-nav li:last-child {
-		margin: 0;
+		margin: 0 0 0 35px;
 	}
 	ul.media-nav a {}
 	ul.media-nav .count {

--- a/wp-media-grid.php
+++ b/wp-media-grid.php
@@ -150,7 +150,6 @@ class WP_Media_Grid {
 		*/
 
 		$items = new WP_Query( $args );
-
 		// Admin header
 		require_once( ABSPATH . 'wp-admin/admin-header.php' );
 	?>
@@ -188,6 +187,13 @@ class WP_Media_Grid {
 				<li class="live-search">
 					<input type="search" placeholder="Search viewable media&hellip;">
 				</li>
+				<li id="total-view-items">
+					<div id="total-items">Found:  <?php 
+						$found = $items->found_posts;
+						echo  '&nbsp;&nbsp;' . $found; if($found<2){?><span>item</span><?php }else{ ?><span>items</span><?php } ?></div>
+					<div id="view-items"></div>
+				</li>
+				<li class="media-select-all"><input type="checkbox" name="media-select-all" value="">Check All</li>
 			</ul>
 
 			<ol class="media-grid">
@@ -261,6 +267,12 @@ class WP_Media_Grid {
 				<div class="media-thumb">
 					<?php echo $thumb; ?>
 				</div>
+				<?php // Reinstating media options popup ?>
+				<ul class="media-options">
+						<li class="media-select"><input type="checkbox" name="media[]" value="<?php echo $item->ID ?>"></li>
+						<li><a class="media-edit" href="<?php echo admin_url( 'post.php?post=' . $item->ID . '&action=edit' ) ?>" title="Edit Details"><span>Edit</span></a></li>
+						<li><a class="submitdelete" href="#">Delete</a></li>
+				</ul>
 				<div class="media-details">
 					<?php echo $tiny_thumb; ?>
 					<h3><?php echo $item->post_title; ?></h3>

--- a/wp-media-grid.php
+++ b/wp-media-grid.php
@@ -403,6 +403,30 @@ function pd_custom_delete() {
 	die();
 }
 add_action('wp_ajax_pd_custom_delete', 'pd_custom_delete');
+function pd_all_items() {
+	$nonce = $_POST['customDeleteNonce'];
+	//Checking nonce
+	if(!wp_verify_nonce($nonce, 'pdajax-custom-delete-nonce')) {
+		die('Not allowed here!');
+	}
+	//Only if user has sufficient permissions
+	if(current_user_can( 'edit_posts' )) {
+		//set the args
+		$args = array(
+			'post_type' => 'attachment',
+			'post_status' => 'inherit',
+			'posts_per_page' => 25,
+			'paged' => 1,
+			'post_mime_type' => 'image'
+			
+		);
+		$items = new WP_Query( $args );
+		WP_Media_Grid::renderMediaItems( $items->posts );
+		//echo $items;
+	}
+	die();
+}
+add_action('wp_ajax_pd_all_items', 'pd_all_items');
 /**
  * Initialize
  */

--- a/wp-media-grid.php
+++ b/wp-media-grid.php
@@ -187,13 +187,13 @@ class WP_Media_Grid {
 				<li class="live-search">
 					<input type="search" placeholder="Search viewable media&hellip;">
 				</li>
+				<li class="media-select-all"><input type="checkbox" name="media-select-all" value=""><span>Check All</span></li>
 				<li id="total-view-items">
-					<div id="total-items">Found:  <?php 
+					<div id="total-items"><?php 
 						$found = $items->found_posts;
-						echo  '&nbsp;&nbsp;' . $found; if($found<2){?><span>item</span><?php }else{ ?><span>items</span><?php } ?></div>
+						echo  '<span class="found">' . $found . '</span>'; if($found==1){?>item<?php }else{ ?>items<?php } ?></div>
 					<div id="view-items"></div>
 				</li>
-				<li class="media-select-all"><input type="checkbox" name="media-select-all" value="">Check All</li>
 			</ul>
 
 			<ol class="media-grid">

--- a/wp-media-grid.php
+++ b/wp-media-grid.php
@@ -203,19 +203,21 @@ class WP_Media_Grid {
 			<div id="add-media">
 				<p>Drop media here to upload, or <button>Browse</button> your computer.</p>				
 			</div>
-
 			<div id="selected-media-details">
 				<div class="selected-meta">
-					<h2 class="selected-count"><strong>0</strong> items selected</h2>
+					<h2 class="selected-count"><strong>0</strong> items selected / &nbsp;&nbsp;&nbsp;Actions:</h2>
 					<ul class="selected-media-options inactive">
-						<li><a class="selected-compare" href="#">Compare</a></li>
-						<?php /* <li><a class="selected-tag" href="<?php echo $_SERVER['REQUEST_URI']; ?>">Tag</a></li> */ ?>
-						<li><a class="selected-unselect" href="#">Unselect</a></li>
-						<?php /* <li><a class="selected-delete" href="#">Delete</a></li> */ ?>
+						<li><a class="selected-delete" href="#"><div class="dashicons dashicons-trash"></div></a></li>
+						<li><a class="selected-tag" href="#"><div class="dashicons dashicons-tag"></div></a></li>
+						<li><a class="selected-unselect" href="#"><button type="button" title="Clear selection" class="bttn_clear_all">Clear selection</button></a></li>
+
+
 					</ul>
 				</div>
+				<?php /* save for later?
 				<ol class="selected-media">
 				</ol>
+				*/ ?>
 			</div>
 
 			<a href="1" class="more-media" data-url="<?php echo $_SERVER['REQUEST_URI']; ?>">Moar!</a>
@@ -271,7 +273,7 @@ class WP_Media_Grid {
 				<ul class="media-options">
 						<li class="media-select"><input type="checkbox" name="media[]" value="<?php echo $item->ID ?>"></li>
 						<li><a class="media-edit" href="<?php echo admin_url( 'post.php?post=' . $item->ID . '&action=edit' ) ?>" title="Edit Details"><span>Edit</span></a></li>
-						<li><a class="submitdelete" href="#">Delete</a></li>
+						<li><a class="media-delete" href="#">Delete</a></li>
 				</ul>
 				<div class="media-details">
 					<?php echo $tiny_thumb; ?>
@@ -375,19 +377,9 @@ function pd_custom_delete() {
 	//Only if user has sufficient permissions
 	if(current_user_can( 'edit_posts' )) {
 		$itemIds = $_POST['itemId'];
-		$update = $_POST['update'];
 		$numID = count($itemIds);
-		if($update) {
-			self::itemsFound($update);
-		}
 		if ($numID == 0){
 			echo 'Did not work';
-		} elseif($numID == 1) {
-			if(false === wp_delete_attachment($itemIds)){
-				echo 'Fail';
-				break;
-			}
-			echo json_encode($itemIds);
 		} else {
 			$responseID = array();
 			foreach($itemIds as $itemId){

--- a/wp-media-grid.php
+++ b/wp-media-grid.php
@@ -152,7 +152,14 @@ class WP_Media_Grid {
 		$items = new WP_Query( $args );
 		// Admin header
 		require_once( ABSPATH . 'wp-admin/admin-header.php' );
-	?>
+
+		/**
+		 * Ajax Messages 
+		 *    -->uses javascript to load and populate
+		 */
+		?>
+		<div id="message" class="updated"></div>
+		
 		<div id="media-library" class="wrap">
 			<h2>Media Library
 				<?php if ( current_user_can( 'upload_files' ) ) { ?>


### PR DESCRIPTION
Hopefully everything is self contained here.  I tried to split up the commits up into manageable chunks.  Still getting the workflow down.  Let me know if there is anything I can do differently.

So user can now select all items on page, or just certain items on page, and delete from a popup that fades in towards bottom of screen (the old .selected-media-details that was commented out but is now much more streamlined).  Clicking on delete icon asks for confirmation than on acceptance sends via ajax to php which calls wp_delete_attachment (which I am assuming is the right way?).  User can also just delete per item which does the same thing.  I have added some user feedback as far as how many items in total vs how many items are viewable (thought it was important for the check-all scenario) vs how many items have been selected (shows up in the selected media popup).
